### PR TITLE
Add service sections and new page layouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import Services from "./pages/Services";
 import Portfolio from "./pages/Portfolio";
 import Articles from "./pages/Articles";
 import Contact from "./pages/Contact";
+import About from "./pages/About";
+import Experience from "./pages/Experience";
+import HireMe from "./pages/HireMe";
 
 const App: React.FC = () => (
   <Router>
@@ -14,6 +17,9 @@ const App: React.FC = () => (
       <Route path="/portfolio" element={<Portfolio />} />
       <Route path="/articles" element={<Articles />} />
       <Route path="/contact" element={<Contact />} />
+      <Route path="/about" element={<About />} />
+      <Route path="/experience" element={<Experience />} />
+      <Route path="/hire-me" element={<HireMe />} />
     </Routes>
   </Router>
 );

--- a/src/components/services/AlternatingSection.tsx
+++ b/src/components/services/AlternatingSection.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+const items = [
+  {
+    img: "https://source.unsplash.com/random/800x600?project",
+    title: "Collaborative Workflow",
+    desc: "Transparent communication and agile methodology ensure projects run smoothly.",
+  },
+  {
+    img: "https://source.unsplash.com/random/800x600?code",
+    title: "Quality Code",
+    desc: "Maintainable and scalable code with best practices at its core.",
+  },
+  {
+    img: "https://source.unsplash.com/random/800x600?support",
+    title: "Ongoing Support",
+    desc: "I provide guidance even after launch to keep your product growing.",
+  },
+];
+
+const AlternatingSection: React.FC = () => (
+  <section className="w-full py-16 bg-surface" id="workflow">
+    <div className="container-80 space-y-16">
+      {items.map((item, idx) => (
+        <motion.div
+          key={idx}
+          className={`flex flex-col md:flex-row items-center gap-6 ${idx % 2 === 1 ? 'md:flex-row-reverse' : ''}`}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+        >
+          <img src={item.img} alt={item.title} className="w-full md:w-1/2 rounded-lg shadow-md object-cover" />
+          <div className="flex-1">
+            <h3 className="text-xl font-semibold text-primary mb-2">{item.title}</h3>
+            <p className="text-gray-700">{item.desc}</p>
+          </div>
+        </motion.div>
+      ))}
+    </div>
+  </section>
+);
+
+export default AlternatingSection;

--- a/src/components/services/CTASection.tsx
+++ b/src/components/services/CTASection.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { Link } from "react-scroll";
+
+const CTASection: React.FC = () => (
+  <section className="w-full py-16 bg-primary text-white text-center">
+    <div className="container-80">
+      <motion.h2
+        className="text-2xl md:text-3xl font-bold mb-6"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+      >
+        Ready to start your project?
+      </motion.h2>
+      <div className="flex flex-col sm:flex-row justify-center gap-4">
+        <Link
+          to="pricing"
+          smooth
+          offset={-50}
+          className="px-6 py-3 bg-accent text-primary rounded font-semibold cursor-pointer"
+        >
+          View Pricing
+        </Link>
+        <a
+          href="/contact"
+          className="px-6 py-3 bg-white text-primary rounded font-semibold"
+        >
+          Contact Me
+        </a>
+      </div>
+    </div>
+  </section>
+);
+
+export default CTASection;

--- a/src/components/services/CardSection.tsx
+++ b/src/components/services/CardSection.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { Code, PenTool, Search } from "lucide-react";
+
+const services = [
+  {
+    icon: PenTool,
+    title: "Design Consultation",
+    desc: "Work closely to transform ideas into polished mockups and prototypes.",
+  },
+  {
+    icon: Code,
+    title: "Web Development",
+    desc: "Responsive websites and applications optimized for performance.",
+  },
+  {
+    icon: Search,
+    title: "SEO & Analytics",
+    desc: "Get discovered faster and understand your audience with data-driven insights.",
+  },
+];
+
+const CardSection: React.FC = () => (
+  <section className="w-full py-16 bg-white">
+    <div className="container-80">
+      <motion.h2
+        className="text-2xl md:text-3xl font-bold text-primary mb-12 text-center"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+      >
+        What I Do
+      </motion.h2>
+      <div className="grid md:grid-cols-3 gap-8">
+        {services.map((item, idx) => {
+          const Icon = item.icon;
+          return (
+            <motion.div
+              key={idx}
+              className="p-6 rounded-lg shadow-md border text-center flex flex-col items-center"
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: idx * 0.1 }}
+            >
+              <Icon className="h-8 w-8 text-accent mb-4" />
+              <h3 className="text-lg font-semibold mb-2">{item.title}</h3>
+              <p className="text-gray-600 text-sm">{item.desc}</p>
+            </motion.div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+);
+
+export default CardSection;

--- a/src/components/services/FAQSection.tsx
+++ b/src/components/services/FAQSection.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import * as Accordion from "@radix-ui/react-accordion";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+import { motion } from "framer-motion";
+
+const faqs = [
+  { question: "How long does a typical project take?", answer: "Timelines vary depending on scope, but most websites are delivered within 4-6 weeks." },
+  { question: "Do you offer ongoing maintenance?", answer: "Yes, I provide flexible maintenance and support packages." },
+  { question: "Can you help with content strategy?", answer: "Absolutely. I work with you to ensure your content aligns with your goals." },
+];
+
+const FAQSection: React.FC = () => (
+  <section className="w-full py-16 bg-surface">
+    <div className="container-80">
+      <motion.h2
+        className="text-2xl md:text-3xl font-bold text-primary mb-8 text-center"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+      >
+        Frequently Asked Questions
+      </motion.h2>
+      <Accordion.Root type="single" collapsible className="space-y-4">
+        {faqs.map((faq, idx) => (
+          <Accordion.Item key={idx} value={`item-${idx}`} className="bg-white rounded-lg shadow-sm">
+            <Accordion.Header>
+              <Accordion.Trigger className="w-full flex justify-between items-center px-4 py-3 text-left font-medium">
+                {faq.question}
+                <ChevronDownIcon className="w-5 h-5" />
+              </Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content className="px-4 pb-4 text-sm text-gray-600">
+              {faq.answer}
+            </Accordion.Content>
+          </Accordion.Item>
+        ))}
+      </Accordion.Root>
+    </div>
+  </section>
+);
+
+export default FAQSection;

--- a/src/components/services/PricingSection.tsx
+++ b/src/components/services/PricingSection.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+const plans = [
+  {
+    name: "Basic",
+    price: "$299",
+    features: ["Consultation", "Single Page", "Email Support"],
+  },
+  {
+    name: "Pro",
+    price: "$799",
+    features: ["Up to 5 Pages", "SEO Setup", "Priority Support"],
+  },
+  {
+    name: "Custom",
+    price: "Let's Talk",
+    features: ["Tailored Solution", "Dedicated Support", "Long-term Partnership"],
+  },
+];
+
+const PricingSection: React.FC = () => (
+  <section id="pricing" className="w-full py-16 bg-white">
+    <div className="container-80 text-center">
+      <motion.h2
+        className="text-2xl md:text-3xl font-bold text-primary mb-12"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+      >
+        Pricing Plans
+      </motion.h2>
+      <div className="grid md:grid-cols-3 gap-8">
+        {plans.map((plan, idx) => (
+          <motion.div
+            key={plan.name}
+            className="border rounded-lg p-6 flex flex-col items-center shadow-sm"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: idx * 0.1 }}
+          >
+            <h3 className="text-lg font-semibold mb-2">{plan.name}</h3>
+            <div className="text-3xl font-bold text-accent mb-4">{plan.price}</div>
+            <ul className="text-sm text-gray-600 space-y-1 mb-6">
+              {plan.features.map(f => (
+                <li key={f}>{f}</li>
+              ))}
+            </ul>
+            <a href="/hire-me" className="px-4 py-2 bg-accent text-primary rounded font-semibold">
+              Choose Plan
+            </a>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default PricingSection;

--- a/src/components/services/SliderSection.tsx
+++ b/src/components/services/SliderSection.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, Pagination } from "swiper/modules";
+import { motion } from "framer-motion";
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+
+const slides = [
+  {
+    img: "https://source.unsplash.com/random/800x600?design",
+    title: "UI/UX Design",
+    desc: "Crafting intuitive and engaging interfaces tailored to your brand.",
+  },
+  {
+    img: "https://source.unsplash.com/random/800x600?frontend",
+    title: "Frontend Development",
+    desc: "Building responsive, performant websites with the latest tech.",
+  },
+  {
+    img: "https://source.unsplash.com/random/800x600?seo",
+    title: "SEO Optimization",
+    desc: "Improving visibility and driving traffic through proven strategies.",
+  },
+];
+
+const SliderSection: React.FC = () => (
+  <section className="w-full py-16 bg-neutral text-white">
+    <div className="container-80">
+      <motion.h2
+        className="text-2xl md:text-3xl font-bold mb-8"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+      >
+        Featured Services
+      </motion.h2>
+      <Swiper
+        modules={[Navigation, Pagination]}
+        navigation
+        pagination={{ clickable: true }}
+        spaceBetween={30}
+        slidesPerView={1}
+      >
+        {slides.map((item, idx) => (
+          <SwiperSlide key={idx}>
+            <div className="flex flex-col md:flex-row gap-6 items-center">
+              <img
+                src={item.img}
+                alt={item.title}
+                className="w-full md:w-1/2 rounded-lg shadow-lg object-cover"
+              />
+              <div className="flex-1">
+                <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+                <p className="text-gray-200">{item.desc}</p>
+              </div>
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  </section>
+);
+
+export default SliderSection;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,12 +1,27 @@
 import React from "react";
-import Navbar from '../components/navbar/Navbar';
+import Navbar from "../components/navbar/Navbar";
+import { motion } from "framer-motion";
 
 const About: React.FC = () => (
   <>
     <Navbar />
-    <main className="mt-12">
-      <h1 className="text-3xl font-bold">Portfolio Page</h1>
-      <p className="mt-2 text-gray-700">This is the portfolio page. Content coming soon!</p>
+    <main className="mt-12 py-16">
+      <div className="container-80 max-w-3xl">
+        <motion.h1
+          className="text-2xl md:text-3xl font-bold text-primary mb-6 text-center"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          About Me
+        </motion.h1>
+        <p className="text-gray-700 mb-4">
+          I'm Fardil Khalidi, a product developer and designer focused on crafting impactful digital experiences. With a background in project management and front-end engineering, I bridge the gap between design and development to deliver high-quality results.
+        </p>
+        <p className="text-gray-700 mb-4">
+          My passion lies in understanding business goals and translating them into scalable solutions. Whether it's building a landing page or developing a complex application, I approach each project with curiosity and care.
+        </p>
+      </div>
     </main>
   </>
 );

--- a/src/pages/Articles.tsx
+++ b/src/pages/Articles.tsx
@@ -1,14 +1,42 @@
 import React from "react";
-import Navbar from '../components/navbar/Navbar';
+import Navbar from "../components/navbar/Navbar";
 
-const About: React.FC = () => (
+const posts = [
+  {
+    title: "Designing For Conversion",
+    date: "May 2024",
+    excerpt: "Practical tips to ensure your website turns visitors into customers.",
+  },
+  {
+    title: "Understanding Core Web Vitals",
+    date: "April 2024",
+    excerpt: "A breakdown of Google's performance metrics and how to hit them.",
+  },
+  {
+    title: "Content Strategy Basics",
+    date: "March 2024",
+    excerpt: "Why quality content matters more than ever in today's digital landscape.",
+  },
+];
+
+const Articles: React.FC = () => (
   <>
     <Navbar />
-    <main className="mt-12">
-      <h1 className="text-3xl font-bold">Articles Page</h1>
-      <p className="mt-2 text-gray-700">This is the portfolio page. Content coming soon!</p>
+    <main className="mt-12 py-16">
+      <div className="container-80">
+        <h1 className="text-2xl md:text-3xl font-bold text-primary mb-8 text-center">Latest Articles</h1>
+        <div className="space-y-8">
+          {posts.map((post) => (
+            <article key={post.title} className="border-b pb-4">
+              <h2 className="text-xl font-semibold text-primary mb-1">{post.title}</h2>
+              <p className="text-sm text-gray-500 mb-2">{post.date}</p>
+              <p className="text-gray-700">{post.excerpt}</p>
+            </article>
+          ))}
+        </div>
+      </div>
     </main>
   </>
 );
 
-export default About;
+export default Articles;

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,14 +1,56 @@
 import React from "react";
-import Navbar from '../components/navbar/Navbar';
+import Navbar from "../components/navbar/Navbar";
+import { useForm } from "react-hook-form";
+import { motion } from "framer-motion";
 
-const Contact: React.FC = () => (
-  <>
-    <Navbar />
-    <main className="mt-12">
-      <h1 className="text-3xl font-bold">Portfolio Page</h1>
-      <p className="mt-2 text-gray-700">This is the portfolio page. Content coming soon!</p>
-    </main>
-  </>
-);
+const Contact: React.FC = () => {
+  const { register, handleSubmit, reset } = useForm();
+  const onSubmit = (data: any) => {
+    console.log(data);
+    reset();
+  };
+
+  return (
+    <>
+      <Navbar />
+      <main className="mt-12 py-16">
+        <div className="container-80">
+          <motion.h1
+            className="text-2xl md:text-3xl font-bold text-primary mb-8 text-center"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+          >
+            Get in Touch
+          </motion.h1>
+          <form onSubmit={handleSubmit(onSubmit)} className="max-w-xl mx-auto space-y-4">
+            <input
+              {...register("name")}
+              placeholder="Name"
+              className="w-full border px-4 py-2 rounded"
+              required
+            />
+            <input
+              {...register("email")}
+              type="email"
+              placeholder="Email"
+              className="w-full border px-4 py-2 rounded"
+              required
+            />
+            <textarea
+              {...register("message")}
+              placeholder="Message"
+              className="w-full border px-4 py-2 rounded h-32"
+              required
+            />
+            <button type="submit" className="px-6 py-3 bg-accent text-primary rounded font-semibold w-full">
+              Send Message
+            </button>
+          </form>
+        </div>
+      </main>
+    </>
+  );
+};
 
 export default Contact;

--- a/src/pages/Experience.tsx
+++ b/src/pages/Experience.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import Navbar from "../components/navbar/Navbar";
+import { motion } from "framer-motion";
+
+const experiences = [
+  { year: "2024", role: "Freelance Developer", desc: "Providing web solutions for various clients." },
+  { year: "2022", role: "UI/UX Designer", desc: "Created user-centric designs for a SaaS startup." },
+  { year: "2020", role: "Project Manager", desc: "Led a remote team delivering digital products." },
+];
+
+const Experience: React.FC = () => (
+  <>
+    <Navbar />
+    <main className="mt-12 py-16">
+      <div className="container-80">
+        <motion.h1
+          className="text-2xl md:text-3xl font-bold text-primary mb-8 text-center"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          Experience
+        </motion.h1>
+        <div className="space-y-8 max-w-2xl mx-auto">
+          {experiences.map((exp) => (
+            <div key={exp.year} className="flex flex-col md:flex-row md:items-center gap-4">
+              <div className="font-semibold text-primary w-24">{exp.year}</div>
+              <div>
+                <div className="font-medium text-gray-800">{exp.role}</div>
+                <p className="text-gray-600 text-sm">{exp.desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  </>
+);
+
+export default Experience;

--- a/src/pages/HireMe.tsx
+++ b/src/pages/HireMe.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import Navbar from "../components/navbar/Navbar";
+import { motion } from "framer-motion";
+
+const HireMe: React.FC = () => (
+  <>
+    <Navbar />
+    <main className="mt-12 py-16">
+      <div className="container-80 text-center">
+        <motion.h1
+          className="text-2xl md:text-3xl font-bold text-primary mb-6"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          Let's Work Together
+        </motion.h1>
+        <p className="text-gray-700 mb-8 max-w-2xl mx-auto">
+          I'm excited to collaborate on new projects. Whether you need design, development, or both, I'm here to help bring your ideas to life.
+        </p>
+        <a href="/contact" className="px-6 py-3 bg-accent text-primary rounded font-semibold">
+          Contact Me
+        </a>
+      </div>
+    </main>
+  </>
+);
+
+export default HireMe;

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,12 +1,46 @@
 import React from "react";
-import Navbar from '../components/navbar/Navbar';
+import Navbar from "../components/navbar/Navbar";
+import CardPortfolio from "../components/CardPortfolio";
+
+const items = [
+  {
+    img: "https://source.unsplash.com/random/500x400?project1",
+    tags: ["Next.js", "Design"],
+    title: "Corporate Landing Page",
+    url: "#",
+  },
+  {
+    img: "https://source.unsplash.com/random/500x400?project2",
+    tags: ["React", "Dashboard"],
+    title: "Analytics Dashboard",
+    url: "#",
+  },
+  {
+    img: "https://source.unsplash.com/random/500x400?project3",
+    tags: ["E-commerce", "UX"],
+    title: "Modern Shop Experience",
+    url: "#",
+  },
+  {
+    img: "https://source.unsplash.com/random/500x400?project4",
+    tags: ["Branding", "Website"],
+    title: "Creative Portfolio Website",
+    url: "#",
+  },
+];
 
 const Portfolio: React.FC = () => (
   <>
     <Navbar />
-    <main className="mt-12">
-      <h1 className="text-3xl font-bold">Portfolio Page</h1>
-      <p className="mt-2 text-gray-700">This is the portfolio page. Content coming soon!</p>
+    <main className="mt-12 py-16">
+      <div className="container-80">
+        <h1 className="text-2xl md:text-3xl font-bold text-primary mb-8 text-center">Recent Projects</h1>
+        <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-8">
+          {items.map((item, i) => (
+            <CardPortfolio key={i} {...item} />
+          ))}
+        </div>
+      </div>
     </main>
   </>
 );

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,14 +1,24 @@
 import React from "react";
-import Navbar from '../components/navbar/Navbar';
+import Navbar from "../components/navbar/Navbar";
+import SliderSection from "../components/services/SliderSection";
+import CardSection from "../components/services/CardSection";
+import AlternatingSection from "../components/services/AlternatingSection";
+import PricingSection from "../components/services/PricingSection";
+import FAQSection from "../components/services/FAQSection";
+import CTASection from "../components/services/CTASection";
 
-const Experience: React.FC = () => (
+const Services: React.FC = () => (
   <>
     <Navbar />
     <main className="mt-12">
-      <h1 className="text-3xl font-bold">Services Page</h1>
-      <p className="mt-2 text-gray-700">This is the portfolio page. Content coming soon!</p>
+      <SliderSection />
+      <CardSection />
+      <AlternatingSection />
+      <PricingSection />
+      <FAQSection />
+      <CTASection />
     </main>
   </>
 );
 
-export default Experience;
+export default Services;


### PR DESCRIPTION
## Summary
- implement service page sections using framer-motion, Swiper, Radix Accordion, react-scroll
- flesh out portfolio, articles, contact, about, experience, and hire-me pages with basic content
- register new routes in `App.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'babel__core')*

------
https://chatgpt.com/codex/tasks/task_e_687ef475b6a8832bb23a10b98189ea83