### PR TITLE
Add homepage and articles pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Home from "./pages/Home";
 import Services from "./pages/Services";
 import Portfolio from "./pages/Portfolio";
 import Articles from "./pages/Articles";
+import ArticleDetail from "./pages/ArticleDetail";
 import Contact from "./pages/Contact";
 import About from "./pages/About";
 import Experience from "./pages/Experience";
@@ -16,6 +17,7 @@ const App: React.FC = () => (
       <Route path="/services" element={<Services />} />
       <Route path="/portfolio" element={<Portfolio />} />
       <Route path="/articles" element={<Articles />} />
+      <Route path="/articles/:slug" element={<ArticleDetail />} />
       <Route path="/contact" element={<Contact />} />
       <Route path="/about" element={<About />} />
       <Route path="/experience" element={<Experience />} />

--- a/src/components/articles/ArticleCard.tsx
+++ b/src/components/articles/ArticleCard.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+export type Article = {
+  slug: string
+  title: string
+  date: string
+  category: string
+  excerpt: string
+}
+
+export default function ArticleCard({ slug, title, date, category, excerpt }: Article) {
+  return (
+    <article className="border rounded-lg p-4 flex flex-col">
+      <h3 className="font-semibold text-lg mb-1">{title}</h3>
+      <div className="text-sm text-gray-500 mb-2">
+        {date} • <span className="capitalize">{category}</span>
+      </div>
+      <p className="text-gray-700 flex-1">{excerpt}</p>
+      <Link to={`/articles/${slug}`} className="mt-4 text-accent font-medium">
+        Read more
+      </Link>
+    </article>
+  )
+}

--- a/src/components/home/Fund.tsx
+++ b/src/components/home/Fund.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+
+export default function Fund() {
+  return (
+    <section className="px-6 md:px-16 py-16 text-center space-y-4">
+      <h2 className="text-3xl font-bold text-primary">Support My Work</h2>
+      <p className="text-gray-700 max-w-xl mx-auto">
+        If you enjoy my content and projects, consider buying me a coffee on
+        Trakteer to keep me going.
+      </p>
+      <a
+        href="https://trakteer.id"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block px-6 py-2 bg-accent text-primary rounded"
+      >
+        Visit Trakteer
+      </a>
+    </section>
+  )
+}

--- a/src/components/home/ImFardil.tsx
+++ b/src/components/home/ImFardil.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+
+export default function ImFardil() {
+  return (
+    <section className="px-6 md:px-16 py-16">
+      <div className="flex flex-col md:flex-row items-center gap-8">
+        <div className="md:w-1/2 space-y-4">
+          <h2 className="text-3xl font-bold text-primary">Hi, I'm Fardil</h2>
+          <p className="text-gray-700 max-w-prose">
+            I'm a multidisciplinary professional focused on shipping products and
+            content that bridge business goals with user needs.
+          </p>
+        </div>
+        <div className="md:w-1/2">
+          <div className="w-full h-48 bg-gray-200 rounded" />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/ProjectFardilWorksWith.tsx
+++ b/src/components/home/ProjectFardilWorksWith.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { FaToolbox } from "react-icons/fa"
+
+const projects = Array.from({ length: 8 }).map((_, i) => ({
+  title: `Project ${i + 1}`,
+  href: "#",
+}))
+
+export default function ProjectFardilWorksWith() {
+  return (
+    <section className="px-6 md:px-16 py-16">
+      <h2 className="text-3xl font-bold text-primary mb-8 text-center">
+        Active Projects
+      </h2>
+      <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-6">
+        {projects.map((p) => (
+          <a
+            key={p.title}
+            href={p.href}
+            className="border rounded-lg p-6 flex flex-col items-center hover:bg-gray-50 transition"
+          >
+            <FaToolbox size={28} className="mb-2" />
+            <span>{p.title}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/SkillSet.tsx
+++ b/src/components/home/SkillSet.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from "react"
+
+type Skill = { label: string; value: number }
+
+type Tab = { title: string; desc: string; skills: Skill[] }
+
+const tabs: Tab[] = [
+  {
+    title: "Product Manager",
+    desc: "Translating ideas into valuable features and roadmaps.",
+    skills: [
+      { label: "Research", value: 80 },
+      { label: "Strategy", value: 85 },
+      { label: "Roadmap", value: 75 },
+      { label: "Analytics", value: 70 },
+      { label: "Leadership", value: 80 },
+    ],
+  },
+  {
+    title: "Project Manager",
+    desc: "Leading teams to deliver projects on time and budget.",
+    skills: [
+      { label: "Planning", value: 85 },
+      { label: "Scrum", value: 80 },
+      { label: "Budgeting", value: 70 },
+      { label: "Reporting", value: 80 },
+      { label: "Risk", value: 75 },
+    ],
+  },
+  {
+    title: "Fullstack Developer",
+    desc: "Building efficient frontend and backend solutions.",
+    skills: [
+      { label: "React", value: 90 },
+      { label: "Node", value: 80 },
+      { label: "Database", value: 75 },
+      { label: "API", value: 85 },
+      { label: "Testing", value: 70 },
+    ],
+  },
+  {
+    title: "Content & Technical Writer",
+    desc: "Crafting guides and docs that are clear and helpful.",
+    skills: [
+      { label: "Documentation", value: 90 },
+      { label: "Blogging", value: 85 },
+      { label: "Editing", value: 80 },
+      { label: "Tutorials", value: 85 },
+      { label: "SEO", value: 70 },
+    ],
+  },
+  {
+    title: "Product Marketing",
+    desc: "Connecting product benefits to target audiences.",
+    skills: [
+      { label: "Messaging", value: 80 },
+      { label: "Campaigns", value: 75 },
+      { label: "Market Fit", value: 70 },
+      { label: "Brand", value: 85 },
+      { label: "Analytics", value: 75 },
+    ],
+  },
+]
+
+export default function SkillSet() {
+  const [active, setActive] = useState(0)
+  const tab = tabs[active]
+
+  return (
+    <section className="px-6 md:px-16 py-16">
+      <div className="flex flex-col md:flex-row gap-8">
+        <div className="md:w-1/3 space-y-4">
+          <h2 className="text-3xl font-bold text-primary">Skill Set & Roles</h2>
+          <p className="text-gray-700">
+            Diverse experience helping teams ship and market great products.
+          </p>
+        </div>
+        <div className="md:w-2/3 space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {tabs.map((t, i) => (
+              <button
+                key={t.title}
+                onClick={() => setActive(i)}
+                className={`px-3 py-1 text-sm rounded-full transition-colors ${active === i ? "bg-accent text-primary" : "bg-gray-200 text-gray-700"}`}
+              >
+                {t.title}
+              </button>
+            ))}
+          </div>
+          <p className="text-gray-700">{tab.desc}</p>
+          <div className="space-y-4">
+            {tab.skills.map((s) => (
+              <div key={s.label}>
+                <div className="flex justify-between text-sm">
+                  <span>{s.label}</span>
+                  <span>{s.value}%</span>
+                </div>
+                <div className="bg-gray-200 h-2 rounded">
+                  <div className="bg-primary h-2 rounded" style={{ width: `${s.value}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/WorkWith.tsx
+++ b/src/components/home/WorkWith.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { FaBriefcase, FaTasks, FaHandsHelping } from "react-icons/fa"
+
+const options = [
+  {
+    icon: <FaBriefcase size={32} />,
+    title: "Hire Full-Time",
+    text: "Looking for a committed team player to grow your product.",
+    button: { text: "Download CV", href: "#/cv" },
+  },
+  {
+    icon: <FaTasks size={32} />,
+    title: "Hire Project Based",
+    text: "Need expertise for a specific project or short term goal.",
+    button: { text: "Download CV", href: "#/cv" },
+  },
+  {
+    icon: <FaHandsHelping size={32} />,
+    title: "Collaborate",
+    text: "Let's team up and build something impactful together.",
+    button: { text: "Contact Me", href: "/contact" },
+  },
+]
+
+export default function WorkWith() {
+  return (
+    <section className="px-6 md:px-16 py-16 space-y-8">
+      <div className="text-center space-y-4">
+        <h2 className="text-3xl font-bold text-primary">Work With Me</h2>
+        <p className="max-w-xl mx-auto text-gray-700">
+          I'm open to new opportunities whether you need a dedicated team member
+          or a reliable partner for your next project.
+        </p>
+      </div>
+      <div className="grid md:grid-cols-3 gap-6">
+        {options.map((o) => (
+          <div
+            key={o.title}
+            className="border rounded-lg p-6 flex flex-col items-center text-center gap-4"
+          >
+            {o.icon}
+            <h3 className="font-semibold text-lg">{o.title}</h3>
+            <p className="text-sm text-gray-600">{o.text}</p>
+            <a
+              className="px-4 py-2 bg-accent text-primary rounded"
+              href={o.button.href}
+            >
+              {o.button.text}
+            </a>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import { FaGithub, FaLinkedin, FaTwitter } from "react-icons/fa"
+
+export default function Footer() {
+  return (
+    <footer className="px-6 md:px-16 py-8 bg-neutral text-white">
+      <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+        <span>&copy; {new Date().getFullYear()} Fardil</span>
+        <div className="flex gap-4">
+          <a href="#" aria-label="GitHub" className="hover:text-accent">
+            <FaGithub />
+          </a>
+          <a href="#" aria-label="LinkedIn" className="hover:text-accent">
+            <FaLinkedin />
+          </a>
+          <a href="#" aria-label="Twitter" className="hover:text-accent">
+            <FaTwitter />
+          </a>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/pages/ArticleDetail.tsx
+++ b/src/pages/ArticleDetail.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { useParams, Link } from "react-router-dom"
+import Navbar from "../components/navbar/Navbar"
+import { articles } from "./articlesData"
+
+export default function ArticleDetail() {
+  const { slug } = useParams()
+  const article = articles.find((a) => a.slug === slug)
+  if (!article) {
+    return (
+      <>
+        <Navbar />
+        <main className="mt-12 px-6 md:px-16 py-16">
+          <p>Article not found.</p>
+          <Link to="/articles" className="text-accent">Back to articles</Link>
+        </main>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main className="mt-12 px-6 md:px-16 py-16 max-w-[720px] mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-primary">{article.title}</h1>
+        <div className="text-sm text-gray-500">
+          {article.date} • <span className="capitalize">{article.category}</span> • 5 min read
+        </div>
+        <p className="text-gray-700 whitespace-pre-line">{article.content}</p>
+        <Link to="/articles" className="text-accent">&larr; Back to articles</Link>
+        <div className="pt-8 border-t">
+          <p className="text-gray-700">Share this article</p>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/src/pages/Articles.tsx
+++ b/src/pages/Articles.tsx
@@ -1,42 +1,36 @@
-import React from "react";
-import Navbar from "../components/navbar/Navbar";
+import React, { useState } from "react"
+import Navbar from "../components/navbar/Navbar"
+import ArticleCard from "../components/articles/ArticleCard"
+import { articles } from "./articlesData"
 
-const posts = [
-  {
-    title: "Designing For Conversion",
-    date: "May 2024",
-    excerpt: "Practical tips to ensure your website turns visitors into customers.",
-  },
-  {
-    title: "Understanding Core Web Vitals",
-    date: "April 2024",
-    excerpt: "A breakdown of Google's performance metrics and how to hit them.",
-  },
-  {
-    title: "Content Strategy Basics",
-    date: "March 2024",
-    excerpt: "Why quality content matters more than ever in today's digital landscape.",
-  },
-];
+const categories = ["All", "Product", "Tech", "Career", "Life"]
 
-const Articles: React.FC = () => (
-  <>
-    <Navbar />
-    <main className="mt-12 py-16">
-      <div className="container-80">
-        <h1 className="text-2xl md:text-3xl font-bold text-primary mb-8 text-center">Latest Articles</h1>
-        <div className="space-y-8">
-          {posts.map((post) => (
-            <article key={post.title} className="border-b pb-4">
-              <h2 className="text-xl font-semibold text-primary mb-1">{post.title}</h2>
-              <p className="text-sm text-gray-500 mb-2">{post.date}</p>
-              <p className="text-gray-700">{post.excerpt}</p>
-            </article>
+export default function Articles() {
+  const [active, setActive] = useState("All")
+  const filtered = active === "All" ? articles : articles.filter((a) => a.category === active)
+
+  return (
+    <>
+      <Navbar />
+      <main className="mt-12 px-6 md:px-16 py-16 space-y-8">
+        <h1 className="text-3xl font-bold text-primary text-center">Latest Articles</h1>
+        <div className="flex justify-center gap-2 flex-wrap">
+          {categories.map((c) => (
+            <button
+              key={c}
+              onClick={() => setActive(c)}
+              className={`px-3 py-1 rounded-full text-sm ${active === c ? "bg-accent text-primary" : "bg-gray-200"}`}
+            >
+              {c}
+            </button>
           ))}
         </div>
-      </div>
-    </main>
-  </>
-);
-
-export default Articles;
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((article) => (
+            <ArticleCard key={article.slug} {...article} />
+          ))}
+        </div>
+      </main>
+    </>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,20 +1,19 @@
-import React from "react";
-import { Navbar } from "../components/navbar";
-import Hero  from "../components/Hero";
-import Portfolio from "../components/PortfolioSec";
-import ShortStorySlider from "../components/ShortStorySlider";
+import ImFardil from "@/components/home/ImFardil"
+import SkillSet from "@/components/home/SkillSet"
+import WorkWith from "@/components/home/WorkWith"
+import Fund from "@/components/home/Fund"
+import ProjectFardilWorksWith from "@/components/home/ProjectFardilWorksWith"
+import Footer from "@/components/layout/Footer"
 
-const Home: React.FC = () => (
-  <>
-    <Navbar />
-    <Hero />
-    <ShortStorySlider />
-    <Portfolio />
-    {/* Content lainnya */}
-    <main className="mt-12">
-      {/* Section hero, dsb */}
+export default function Home() {
+  return (
+    <main className="space-y-20">
+      <ImFardil />
+      <SkillSet />
+      <WorkWith />
+      <Fund />
+      <ProjectFardilWorksWith />
+      <Footer />
     </main>
-  </>
-);
-
-export default Home;
+  )
+}

--- a/src/pages/articlesData.ts
+++ b/src/pages/articlesData.ts
@@ -1,0 +1,51 @@
+export type Article = {
+  slug: string
+  title: string
+  date: string
+  category: string
+  excerpt: string
+  content: string
+}
+
+export const articles: Article[] = [
+  {
+    slug: "product-vision",
+    title: "Shaping a Product Vision",
+    date: "10 May 2024",
+    category: "Product",
+    excerpt:
+      "Practical ways to craft a vision that guides your team and excites stakeholders.",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod ullamcorper metus, ac ultricies justo auctor sed. Curabitur vel turpis in lorem mollis commodo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;",
+  },
+  {
+    slug: "modern-stack",
+    title: "Picking a Modern Tech Stack",
+    date: "22 Apr 2024",
+    category: "Tech",
+    excerpt:
+      "Choosing the right tools for scalability without overcomplicating things.",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod ullamcorper metus, ac ultricies justo auctor sed. Curabitur vel turpis in lorem mollis commodo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;",
+  },
+  {
+    slug: "career-growth",
+    title: "Planning Your Career Growth",
+    date: "01 Apr 2024",
+    category: "Career",
+    excerpt:
+      "Strategies to map out your professional journey and stay motivated.",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod ullamcorper metus, ac ultricies justo auctor sed. Curabitur vel turpis in lorem mollis commodo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;",
+  },
+  {
+    slug: "work-life",
+    title: "Balancing Work and Life",
+    date: "15 Mar 2024",
+    category: "Life",
+    excerpt:
+      "Keeping productivity high without sacrificing your well-being.",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod ullamcorper metus, ac ultricies justo auctor sed. Curabitur vel turpis in lorem mollis commodo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;",
+  },
+]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,7 +19,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   base: '/', // default, bisa diabaikan
-  plugins: [],
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- build new homepage layout using custom components
- implement article listing and detail pages
- add shared article data
- configure TS paths and Vite alias

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm run build` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68806bba2af4832bab800747c659e719